### PR TITLE
feat: add platform engineer user entity and developer group

### DIFF
--- a/org.yaml
+++ b/org.yaml
@@ -25,6 +25,19 @@ spec:
   children: []
 ---
 apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: developers
+  description: Red Hat Developer Hub
+spec:
+  type: team
+  profile:
+    # Intentional no displayName for testing
+    email: rhdh@opentlc.com
+    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
+  children: []
+---
+apiVersion: backstage.io/v1alpha1
 kind: User
 metadata:
   name: pe
@@ -70,5 +83,5 @@ spec:
     # Intentional no displayName for testing
     email: user{{ index + 1 }}@opentlc.com
     picture: https://avatars.dicebear.com/api/avataaars/breanna-davison@example.com.svg?background=%23fff
-  memberOf: [user{{ index + 1 }}]
+  memberOf: [user{{ index + 1 }}, developers]
 {% endfor %}

--- a/org.yaml
+++ b/org.yaml
@@ -12,6 +12,19 @@ spec:
   children: []
 ---
 apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: rhdh
+  description: Red Hat Developer Hub
+spec:
+  type: team
+  profile:
+    # Intentional no displayName for testing
+    email: rhdh@opentlc.com
+    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
+  children: []
+---
+apiVersion: backstage.io/v1alpha1
 kind: User
 metadata:
   name: pe

--- a/org.yaml
+++ b/org.yaml
@@ -12,17 +12,26 @@ spec:
   children: []
 ---
 apiVersion: backstage.io/v1alpha1
-kind: Group
+kind: User
 metadata:
-  name: rhdh
-  description: Red Hat Developer Hub
+  name: pe
 spec:
-  type: team
+  profile:
+    displayName: Platform Engineer
+    email: pe@demo.redhat.com
+    picture: https://api.dicebear.com/9.x/fun-emoji/svg?seed=Caleb
+  memberOf: [rhdh]
+apiVersion: backstage.io/v1alpha1
+---
+kind: User
+metadata:
+  name: pe
+spec:
   profile:
     # Intentional no displayName for testing
-    email: rhdh@opentlc.com
-    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
-  children: []
+    email: pe@demo.redhat.com
+    picture: https://api.dicebear.com/9.x/fun-emoji/svg?seed=Caleb
+  memberOf: [rhdh]
 {% for index in range(0, gitlab_user_count | int, 1) %}
 ---
 apiVersion: backstage.io/v1alpha1

--- a/org.yaml
+++ b/org.yaml
@@ -8,7 +8,7 @@ spec:
   profile:
     # Intentional no displayName for testing
     email: ad-workshop-authors@demo.redhat.com
-    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
+    picture: https://api.dicebear.com/9.x/shapes/svg?seed=George
   children: []
 ---
 apiVersion: backstage.io/v1alpha1
@@ -21,7 +21,7 @@ spec:
   profile:
     # Intentional no displayName for testing
     email: rhdh@opentlc.com
-    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
+    picture: https://api.dicebear.com/9.x/shapes/svg?seed=Jessica
   children: []
 ---
 apiVersion: backstage.io/v1alpha1
@@ -34,7 +34,7 @@ spec:
   profile:
     # Intentional no displayName for testing
     email: developers@opentlc.com
-    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
+    picture: https://api.dicebear.com/9.x/shapes/svg?seed=Riley
   children: []
 ---
 apiVersion: backstage.io/v1alpha1
@@ -45,19 +45,9 @@ spec:
   profile:
     displayName: Platform Engineer
     email: pe@demo.redhat.com
-    picture: https://api.dicebear.com/9.x/fun-emoji/svg?seed=Caleb
+    picture: https://api.dicebear.com/9.x/thumbs/svg?seed=Eden
   memberOf: [rhdh]
-apiVersion: backstage.io/v1alpha1
----
-kind: User
-metadata:
-  name: pe
-spec:
-  profile:
-    # Intentional no displayName for testing
-    email: pe@demo.redhat.com
-    picture: https://api.dicebear.com/9.x/fun-emoji/svg?seed=Caleb
-  memberOf: [rhdh]
+{% set user_images = ['Sophia', 'Amaya', 'Liam', 'Valentina', 'George'] %}
 {% for index in range(0, gitlab_user_count | int, 1) %}
 ---
 apiVersion: backstage.io/v1alpha1
@@ -70,7 +60,7 @@ spec:
   profile:
     # Intentional no displayName for testing
     email: user{{ index + 1 }}@opentlc.com
-    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
+    picture: https://api.dicebear.com/9.x/shapes/svg?seed=Mackenzie
   parent: rhdh
   children: []
 ---
@@ -82,6 +72,6 @@ spec:
   profile:
     # Intentional no displayName for testing
     email: user{{ index + 1 }}@opentlc.com
-    picture: https://avatars.dicebear.com/api/avataaars/breanna-davison@example.com.svg?background=%23fff
+    picture: https://api.dicebear.com/9.x/thumbs/svg?seed={{ user_images[index % user_images | length] }}
   memberOf: [user{{ index + 1 }}, developers]
 {% endfor %}

--- a/org.yaml
+++ b/org.yaml
@@ -28,12 +28,12 @@ apiVersion: backstage.io/v1alpha1
 kind: Group
 metadata:
   name: developers
-  description: Red Hat Developer Hub
+  description: Developers
 spec:
   type: team
   profile:
     # Intentional no displayName for testing
-    email: rhdh@opentlc.com
+    email: developers@opentlc.com
     picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
   children: []
 ---


### PR DESCRIPTION
## What does this PR do / why we need it

Enables a new platform engineer user to login. Linked PR https://github.com/redhat-gpte-devopsautomation/agnosticg/pull/5

It also creates a `developers` group for `user1..userN`, and fixes the avatar URLs to use the newer format by dicebear.

In theory we can avoid the need to hardcode these entities in the future, by using the GitLab Org plugin and structuring groups in GitLab appropriately. It will depend on this [issue being resolved](https://issues.redhat.com/browse/RHIDP-5319)

## How to test changes / Special notes to the reviewer

You can add this entity to the _org.yaml_ on an existing RHDH demo cluster and create the user manually in GitLab using the following cURL command. You should be able to login to RHDH as the `pe` user after completing both of these steps.

```bash
curl --request POST \
    --url "$GITLAB_HOST/api/v4/users" \
    --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
    --header "Content-Type: application/x-www-form-urlencoded" \
    --data-urlencode "admin=false" \
    --data-urlencode "email=pe@demo.com" \
    --data-urlencode "public_email=pe@demo.com" \
    --data-urlencode "skip_confirmation=true" \
    --data-urlencode "username=pe" \
    --data-urlencode "password=$PE_PASSWORD" \
    --data-urlencode "name=Platform Engineer"
```